### PR TITLE
Fix LEB128 encoding

### DIFF
--- a/src/Couchbase/Core/IO/Operations/Legacy/OperationBase.cs
+++ b/src/Couchbase/Core/IO/Operations/Legacy/OperationBase.cs
@@ -180,9 +180,9 @@ namespace Couchbase.Core.IO.Operations.Legacy
             var buffer = new byte[length];
             if (Cid.HasValue)
             {
-                var leb128Bytes = Leb128.Write(Cid.Value, 2);
+                var leb128Bytes = Leb128.Write(Cid.Value);
                 Buffer.BlockCopy(leb128Bytes, 0, buffer, 0, leb128Bytes.Length);
-                Converter.FromString(Key, buffer, 2);
+                Converter.FromString(Key, buffer, leb128Bytes.Length);
             }
             else
             {

--- a/src/Couchbase/Core/Utils/Leb128.cs
+++ b/src/Couchbase/Core/Utils/Leb128.cs
@@ -1,24 +1,29 @@
-﻿
 using System;
+using System.Collections.Generic;
 
 namespace Couchbase.Core.Utils
 {
     public static class Leb128
     {
-        public static byte[] Write(uint value, int size)
+        public static byte[] Write(uint value)
         {
-            var remaining = value >> 7;
-            var bytes = new byte[size];
-            var count = 0;
+            var bytes = new List<byte>();
 
-            while (remaining != 0)
+            do
             {
-                bytes[count++] = (byte) ((value & 0x7f) | 0x80);
-                value = remaining;
-                remaining = remaining >> 7;
-            }
-            bytes[count] = (byte) (value & 0x7f);
-            return bytes;
+                // get next 7 lower bits
+                var @byte = (byte) (value & 0x7f);
+                value >>= 7;
+
+                if (value != 0) // more bytes to come
+                {
+                    @byte ^= 0x80; // set highest bit
+                }
+
+                bytes.Add(@byte);
+            } while (value != 0);
+
+            return bytes.ToArray();
         }
 
         public static uint Read(byte[] bytes)

--- a/tests/Couchbase.UnitTests/Core/Utils/Leb128Tests.cs
+++ b/tests/Couchbase.UnitTests/Core/Utils/Leb128Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices.WindowsRuntime;
+using System;
 using Couchbase.Core.Utils;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,13 +15,18 @@ namespace Couchbase.UnitTests.Core.Utils
         }
 
         [Theory]
-        [InlineData(555, new byte[]{ 0xab, 0x04})]
-        [InlineData(0x43, new byte[]{0x0, 0x0})]
-        [InlineData(0x5612a, new byte[]{0x0, 0x0})]
+        [InlineData(555, new byte[] {0xab, 0x04})]
+        [InlineData(0x43, new byte[] {0x43})]
+        [InlineData(0x5612a, new byte[] {0xAA, 0xC2, 0x15})]
+        [InlineData(uint.MinValue, new byte[] {0x00})]
+        [InlineData(uint.MaxValue, new byte[] {0xFF, 0xFF, 0xFF, 0xFF, 0x0F})]
         public void Test_Write(uint value, byte[] expected)
         {
-            var bytes = Leb128.Write(value, 2);
+            var bytes = Leb128.Write(value);
             Assert.Equal(expected, bytes);
+
+            var decoded = Leb128.Read(bytes);
+            Assert.Equal(value, decoded);
         }
 
         [Theory]


### PR DESCRIPTION
- uses variable length byte length instead of static 2 bytes