### PR TITLE
Target NetStandard2.0

### DIFF
--- a/src/Couchbase/Couchbase.csproj
+++ b/src/Couchbase/Couchbase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,6 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />

--- a/src/Couchbase/CouchbaseBucket.cs
+++ b/src/Couchbase/CouchbaseBucket.cs
@@ -85,7 +85,7 @@ namespace Couchbase
                 var uri = new UriBuilder
                 {
                     Scheme = Uri.UriSchemeHttp,
-                    Host = server.Split(":")[0]
+                    Host = server.Split(':')[0]
                 }.Uri;
 
                 var ipAddress = uri.GetIpAddress(false);

--- a/src/Couchbase/Utils/IpEndpointExtensions.cs
+++ b/src/Couchbase/Utils/IpEndpointExtensions.cs
@@ -62,7 +62,7 @@ namespace Couchbase.Utils
 
         public static IPEndPoint GetEndPoint(string server)
         {
-            return server.Contains('.') && !server.Contains("[") ?
+            return server.Contains(".") && !server.Contains("[") ?
                 GetIPv4EndPoint(server) :
                 GetIPv6EndPoint(server);
         }


### PR DESCRIPTION
- adds Microsoft.CSharp as package reference
- fix up some char <> string bugs caused by changing target framwork