### PR TITLE
Fix MSB3243 warning message for System.

### DIFF
--- a/src/Couchbase/Couchbase.csproj
+++ b/src/Couchbase/Couchbase.csproj
@@ -53,10 +53,4 @@
     <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System">
-      <HintPath>System</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes MSB324 No way to resolve conflict between "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" and "System". Choosing "System, Version=4.