### PR TITLE
NCBC-1851: Fix struct immutability issues when using options/actions

### DIFF
--- a/src/Couchbase/Options.cs
+++ b/src/Couchbase/Options.cs
@@ -6,7 +6,7 @@ namespace Couchbase
 {
     #region GetOptions
 
-    public struct GetOptions
+    public class GetOptions
     {
         public bool IncludeExpiration { get; set; }
 
@@ -52,7 +52,7 @@ namespace Couchbase
 
     #region Exists Options
 
-    public struct ExistsOptions
+    public class ExistsOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -63,7 +63,7 @@ namespace Couchbase
 
     #region Upsert Options
 
-    public struct UpsertOptions
+    public class UpsertOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -84,7 +84,7 @@ namespace Couchbase
 
     #region Insert Options
 
-    public struct InsertOptions
+    public class InsertOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -105,7 +105,7 @@ namespace Couchbase
 
     #region Replace Options
 
-    public struct ReplaceOptions
+    public class ReplaceOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -126,7 +126,7 @@ namespace Couchbase
 
     #region Remove Options
 
-    public struct RemoveOptions
+    public class RemoveOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -145,7 +145,7 @@ namespace Couchbase
 
     #region Unlock Options
 
-    public struct UnlockOptions
+    public class UnlockOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -158,7 +158,7 @@ namespace Couchbase
 
     #region Touch Options
 
-    public struct TouchOptions
+    public class TouchOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -222,7 +222,7 @@ namespace Couchbase
 
     #region GetAndLock Options
 
-    public struct GetAndLockOptions
+    public class GetAndLockOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -233,7 +233,7 @@ namespace Couchbase
 
     #region GetAndTouch Options
 
-    public struct GetAndTouchOptions
+    public class GetAndTouchOptions
     {
         public TimeSpan? Timeout { get; set; }
 
@@ -246,7 +246,7 @@ namespace Couchbase
 
     #region LookupInOptions
 
-    public struct LookupInOptions
+    public class LookupInOptions
     {
         internal TimeSpan _Timeout { get; set; }
 
@@ -269,7 +269,7 @@ namespace Couchbase
 
     #region MutateInOptions
 
-    public struct MutateInOptions
+    public class MutateInOptions
     {
         internal TimeSpan _Timeout { get; set; }
 

--- a/tests/Couchbase.UnitTests/OptionsTests.cs
+++ b/tests/Couchbase.UnitTests/OptionsTests.cs
@@ -1,64 +1,58 @@
 ﻿using System;
-using System.Collections.Generic;
-using Couchbase.UnitTests.Helpers.Wintellect;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Couchbase.UnitTests
 {
     public class OptionsTests
     {
-        private readonly ITestOutputHelper output;
-
-        public OptionsTests(ITestOutputHelper output)
+        [Fact]
+        public void GetOptions_Action_Succeeds()
         {
-            this.output = output;
+            Action<GetOptions> optionsAction = get =>
+            {
+                get.WithCreatePath(true);
+                get.WithTimeout(new TimeSpan(1, 1, 1));
+            };
+
+            var options = new GetOptions();
+            optionsAction(options);
+
+            Assert.Equal(new TimeSpan(1, 1, 1), options.Timeout);
+            Assert.True(options.CreatePath);
         }
 
         [Fact]
-        public void Test_GetOptions()
+        public void StructOptions_Action_Failed()
         {
-            using (var op = new OperationTimer(output))
+            Action<StructOptions> optionsAction = get =>
             {
-                for (int i = 0; i < 10000; i++)
-                {
-                    var option = new MutateInOptions().Timeout(new TimeSpan(1, 1, 1));
-                }
-            }
+                get.WithCreatePath(true);
+                get.WithTimeout(new TimeSpan(1, 1, 1));
+            };
+
+            var options = new StructOptions();
+            optionsAction(options);
+
+            Assert.Null(options.Timeout);
+            Assert.False(options.CreatePath);
         }
 
-        [Fact]
-        public void Test_InsertOptions()
+        public struct StructOptions
         {
-            using (var op = new OperationTimer(output))
+            public bool CreatePath { get; set; }
+
+            public TimeSpan? Timeout { get; set; }
+
+            public StructOptions WithTimeout(TimeSpan timeout)
             {
-                var options = new InsertOptions
-                {
-                    ReplicateTo = ReplicateTo.One,
-                    PersistTo = PersistTo.Four,
-                    Cas = long.MaxValue,
-                    Timeout = new TimeSpan(0, 0, 1),
-                    Expiration = new TimeSpan(0, 0, 3)
-                };
+                Timeout = timeout;
+                return this;
             }
 
-            var count = 1000000;
-
-            InsertOptions options1;
-            using (var op = new OperationTimer(output))
+            public StructOptions WithCreatePath(bool createPath)
             {
-                while (count-- > 0)
-                {
-                    options1 = new InsertOptions() {
-                        ReplicateTo = ReplicateTo.One,
-                        //PersistTo = PersistTo.Four,
-                        Cas = long.MaxValue,
-                        Timeout = new TimeSpan(0, 0, 1),
-                        Expiration = new TimeSpan(0, 0, 3)
-                    };
-
-                   // output.WriteLine(count.ToString());
-                }
+                CreatePath = createPath;
+                return this;
             }
         }
     }


### PR DESCRIPTION
Motivation
----------
Make XxxOption classes instead of structs so that we can use them as T
of Action<T> so that there properties are copied over and can be used.

Modification
------------
 - Make all XxxOption structs classes.
 - Add unit test and example

Result
------
When lambda options are used there properties are carried over.