### PR TITLE
NCBC-1852: Use 'http' scheme for Query

### DIFF
--- a/src/Couchbase/Services/Query/QueryClient.cs
+++ b/src/Couchbase/Services/Query/QueryClient.cs
@@ -47,6 +47,7 @@ namespace Couchbase.Services.Query
         {
             var uriBuilder = new UriBuilder(Configuration.Servers.GetRandom())
             {
+                Scheme = "http",
                 Path = "/query",
                 Port = 8093
             };


### PR DESCRIPTION
Motivation
----------
Fixes a bug where the "couchbase://" scheme is not supported.

Modification
------------
Set the URI Scheme to "http"

Result
------
Queries work as expected. Further wrok needs to be done to enable
SSL/TLS.