### PR TITLE
NCBC-1853: Make VBucket.VBucketIndex a short

### DIFF
--- a/src/Couchbase/Core/Sharding/IVBucket.cs
+++ b/src/Couchbase/Core/Sharding/IVBucket.cs
@@ -12,12 +12,12 @@ namespace Couchbase.Core.Sharding
         /// </summary>
         /// <param name="index">The index of the replica.</param>
         /// <returns>An <see cref="IServer"/> if the replica is found, otherwise null.</returns>
-        IPEndPoint LocateReplica(int index);
+        IPEndPoint LocateReplica(short index);
 
         /// <summary>
         /// Gets an array of replica indexes.
         /// </summary>
-        int[] Replicas { get; }
+        short[] Replicas { get; }
 
         /// <summary>
         /// Gets the index of the VBucket.
@@ -25,7 +25,7 @@ namespace Couchbase.Core.Sharding
         /// <value>
         /// The index.
         /// </value>
-        int Index { get; }
+        short Index { get; }
 
         /// <summary>
         /// Gets the index of the primary node in the VBucket.
@@ -33,7 +33,7 @@ namespace Couchbase.Core.Sharding
         /// <value>
         /// The primary index that the key has mapped to.
         /// </value>
-        int Primary { get; }
+        short Primary { get; }
 
         /// <summary>
         /// Gets a value indicating whether this instance has replicas.

--- a/src/Couchbase/Core/Sharding/VBucket.cs
+++ b/src/Couchbase/Core/Sharding/VBucket.cs
@@ -11,11 +11,12 @@ namespace Couchbase.Core.Sharding
     /// </summary>
     internal class VBucket : IVBucket
     {
-        private readonly int[] _replicas;
+        private readonly short[] _replicas;
         private readonly VBucketServerMap _vBucketServerMap;
         private readonly ICollection<IPEndPoint> _endPoints;
 
-        public VBucket(ICollection<IPEndPoint> endPoints, int index, int primary, int[] replicas, uint rev, VBucketServerMap vBucketServerMap, string bucketName)
+        public VBucket(ICollection<IPEndPoint> endPoints, short index, short primary, short[] replicas, uint rev,
+            VBucketServerMap vBucketServerMap, string bucketName)
         {
             _endPoints = endPoints;
             Index = index;
@@ -73,7 +74,7 @@ namespace Couchbase.Core.Sharding
         /// </summary>
         /// <param name="index">The index of the replica.</param>
         /// <returns>An <see cref="IServer"/> if the replica is found, otherwise null.</returns>
-        public IPEndPoint LocateReplica(int index)
+        public IPEndPoint LocateReplica(short index)
         {
             try
             {
@@ -89,7 +90,7 @@ namespace Couchbase.Core.Sharding
         /// <summary>
         /// Gets an array of replica indexes.
         /// </summary>
-        public int[] Replicas => _replicas;
+        public short[] Replicas => _replicas;
 
         /// <summary>
         /// Gets the index of the VBucket.
@@ -97,7 +98,7 @@ namespace Couchbase.Core.Sharding
         /// <value>
         /// The index.
         /// </value>
-        public int Index { get; }
+        public short Index { get; }
 
         /// <summary>
         /// Gets the index of the primary node in the VBucket.
@@ -105,7 +106,7 @@ namespace Couchbase.Core.Sharding
         /// <value>
         /// The primary index that the key has mapped to.
         /// </value>
-        public int Primary { get; }
+        public short Primary { get; }
 
         /// <summary>
         /// Gets or sets the configuration revision.

--- a/src/Couchbase/Core/Sharding/VBucketServerMap.cs
+++ b/src/Couchbase/Core/Sharding/VBucketServerMap.cs
@@ -17,8 +17,8 @@ namespace Couchbase.Core.Sharding
             HashAlgorithm = string.Empty;
             NumReplicas = 0;
             ServerList = new string[0];
-            VBucketMap = new int[0][];
-            VBucketMapForward = new int[0][];
+            VBucketMap = new short[0][];
+            VBucketMapForward = new short[0][];
         }
 
         [JsonProperty("hashAlgorithm")]
@@ -31,10 +31,10 @@ namespace Couchbase.Core.Sharding
         public string[] ServerList { get; set; }
 
         [JsonProperty("vBucketMap")]
-        public int[][] VBucketMap { get; set; }
+        public short[][] VBucketMap { get; set; }
 
         [JsonProperty("vBucketMapForward")]
-        public int[][] VBucketMapForward { get; set; }
+        public short[][] VBucketMapForward { get; set; }
 
         [JsonIgnore]
         public List<IPEndPoint> IPEndPoints
@@ -50,8 +50,8 @@ namespace Couchbase.Core.Sharding
         {
             return (other != null
                     && ServerList.AreEqual<string>(other.ServerList)
-                    && VBucketMap.AreEqual(other.VBucketMap))
-                    && VBucketMapForward.AreEqual(other.VBucketMapForward);
+                    && VBucketMap.AreEqual<short>(other.VBucketMap))
+                    && VBucketMapForward.AreEqual<short>(other.VBucketMapForward);
         }
 
         public override bool Equals(object obj)

--- a/src/Couchbase/CouchbaseBucket.cs
+++ b/src/Couchbase/CouchbaseBucket.cs
@@ -280,7 +280,7 @@ namespace Couchbase
         public async Task Send(IOperation op, TaskCompletionSource<byte[]> tcs)
         {
             var vBucket = (VBucket) _keyMapper.MapKey(op.Key);
-            op.VBucketId = (short?)vBucket.Index; //hack - make vBucketIndex a short
+            op.VBucketId = vBucket.Index; //hack - make vBucketIndex a short
 
             var node =  vBucket.LocatePrimary();
             await Connections[node].SendAsync(op.Write(), op.Completed).ConfigureAwait(false);


### PR DESCRIPTION
Motivation
----------
The server expects VBucket Index to be a short between 0 and 1023 -
change the client to map to shorts instead of ints.

Modifications
-------------
Change all int types to shorts in:
 - IVBucket.cs
 - VBucket.cs
 - VBucketKeyMapper.cs
 - VBucketServerMap.cs
 - CouchbaseBucket.cs

Result
------
Client now uses shorts for VBucket indexing.