### PR TITLE
NCBC-1856: Default parameter value for 'options' must be a compile-ti…

### DIFF
--- a/src/Couchbase/CouchbaseCollection.cs
+++ b/src/Couchbase/CouchbaseCollection.cs
@@ -99,7 +99,7 @@ namespace Couchbase
             return Get(id, options);
         }
 
-        public async Task<IGetResult> Get(string id, GetOptions options = new GetOptions())
+        public async Task<IGetResult> Get(string id, GetOptions options)
         {
             //A projection operation
             var enumerable = options.ProjectList ?? new List<string>();


### PR DESCRIPTION
…me const

Motivation
----------
Fixes a compile time bug where an optional paremeter is not a compile
time constant.

Changes
-------
Set GetOptions to its default

Result
------
Couchbase project builds.